### PR TITLE
Update named-arguments.ts

### DIFF
--- a/code/named-arguments.ts
+++ b/code/named-arguments.ts
@@ -1,1 +1,4 @@
-------
+function area({ width, height }: { width: number, height: number }): number {
+    return width * height
+}
+area({ width: 2, height: 3 })


### PR DESCRIPTION
While TypeScript 4.0 has added support for labeled tuples
```ts
function area([width, height]: [width: number, height: number]): number {
    return width * height
}
area([2, 3])
```
the more idiomatic way of doing named parameters in JavaScript/TypeScript is using an object literal